### PR TITLE
Potential fix for code scanning alert no. 137: Code injection

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -46,12 +46,14 @@ jobs:
 
       - name: Get changed add-ons
         id: changed_addons
+        env:
+          CHANGED_FILES: ${{ steps.changed_files.outputs.all }}
         run: |
           declare -a changed_addons
           for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
+            if [[ "$CHANGED_FILES" =~ $addon ]]; then
               for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
+                  if [[ "$CHANGED_FILES" =~ $addon/$file ]]; then
                     if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
                       changed_addons+=("\"${addon}\",");
                     fi


### PR DESCRIPTION
Potential fix for [https://github.com/BigThunderSR/homeassistant-addons-onstar2mqtt/security/code-scanning/137](https://github.com/BigThunderSR/homeassistant-addons-onstar2mqtt/security/code-scanning/137)

To fix the problem, we should avoid directly using the potentially unsafe `${{ steps.changed_files.outputs.all }}` in the shell script. Instead, we can assign the value to an environment variable and then use the environment variable in the shell script. This approach ensures that the value is treated as a string and not executed as code.

We will modify the `run` step to set an environment variable for `${{ steps.changed_files.outputs.all }}` and then use this environment variable in the shell script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
