### PR TITLE
Implement alternative for deprecated jitterbit action

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -38,7 +38,8 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        #uses: jitterbit/get-changed-files@v1
+        uses: HanseltimeIndustries/get-changed-files@v1.1.2
 
       - name: Find add-on directories
         id: addons


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/builder.yaml` file to update the action used for getting changed files. The change comments out the previous action and replaces it with an updated version from a different repository.

* [`.github/workflows/builder.yaml`](diffhunk://#diff-c5fb9d7d821ca8e489c7a19d9761fd13a6e47ad5a201b20838f2f9364096b5eeL41-R42): Updated the `get-changed-files` action from `jitterbit/get-changed-files@v1` to `HanseltimeIndustries/get-changed-files@v1.1.2`.