### PR TITLE
Comment out Deprecated Codenotary Configuration in build.yaml Files

### DIFF
--- a/onstar2mqtt-bigthundersr-vehicle1/build.yaml
+++ b/onstar2mqtt-bigthundersr-vehicle1/build.yaml
@@ -2,6 +2,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-codenotary:
-  base_image: notary@home-assistant.io
-  signer: bigthundersr@outlook.com
+#codenotary:
+#  base_image: notary@home-assistant.io
+#  signer: bigthundersr@outlook.com

--- a/onstar2mqtt-bigthundersr-vehicle2/build.yaml
+++ b/onstar2mqtt-bigthundersr-vehicle2/build.yaml
@@ -2,6 +2,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-codenotary:
-  base_image: notary@home-assistant.io
-  signer: bigthundersr@outlook.com
+#codenotary:
+#  base_image: notary@home-assistant.io
+#  signer: bigthundersr@outlook.com

--- a/onstar2mqtt-bigthundersr-vehicle3/build.yaml
+++ b/onstar2mqtt-bigthundersr-vehicle3/build.yaml
@@ -2,6 +2,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-codenotary:
-  base_image: notary@home-assistant.io
-  signer: bigthundersr@outlook.com
+#codenotary:
+#  base_image: notary@home-assistant.io
+#  signer: bigthundersr@outlook.com

--- a/onstar2mqtt-bigthundersr-vehicle4/build.yaml
+++ b/onstar2mqtt-bigthundersr-vehicle4/build.yaml
@@ -2,6 +2,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-codenotary:
-  base_image: notary@home-assistant.io
-  signer: bigthundersr@outlook.com
+#codenotary:
+#  base_image: notary@home-assistant.io
+#  signer: bigthundersr@outlook.com

--- a/x-test-onstar2mqtt-bigthundersr-vehicleX/build.yaml
+++ b/x-test-onstar2mqtt-bigthundersr-vehicleX/build.yaml
@@ -2,6 +2,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-codenotary:
-  base_image: notary@home-assistant.io
-  signer: bigthundersr@outlook.com
+#codenotary:
+#  base_image: notary@home-assistant.io
+#  signer: bigthundersr@outlook.com

--- a/y-test-onstar2mqtt-bigthundersr-vehicleY/build.yaml
+++ b/y-test-onstar2mqtt-bigthundersr-vehicleY/build.yaml
@@ -2,6 +2,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-codenotary:
-  base_image: notary@home-assistant.io
-  signer: bigthundersr@outlook.com
+#codenotary:
+#  base_image: notary@home-assistant.io
+#  signer: bigthundersr@outlook.com

--- a/z-test-onstar2mqtt-bigthundersr-vehicleZ/build.yaml
+++ b/z-test-onstar2mqtt-bigthundersr-vehicleZ/build.yaml
@@ -2,6 +2,6 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-codenotary:
-  base_image: notary@home-assistant.io
-  signer: bigthundersr@outlook.com
+#codenotary:
+#  base_image: notary@home-assistant.io
+#  signer: bigthundersr@outlook.com


### PR DESCRIPTION
This pull request comments out the deprecated `codenotary` section in the `build.yaml` files for all vehicle-specific and test add-ons.
