### PR TITLE
Comment Out Deprecated codenotary Configuration in config Files

### DIFF
--- a/onstar2mqtt-bigthundersr-vehicle1/config.yaml
+++ b/onstar2mqtt-bigthundersr-vehicle1/config.yaml
@@ -2,7 +2,7 @@ name: OnStar2MQTT Home Assistant Add-on (BigThunderSR) for Vehicle 1
 version: 2.2.1
 slug: onstar2mqtt_bigthundersr_vehicle1
 description: Home Assistant Add On Version of BigThunderSR/onstar2mqtt for Vehicle 1
-codenotary: bigthundersr@outlook.com
+#codenotary: bigthundersr@outlook.com
 #startup: application
 #boot: auto
 arch:

--- a/onstar2mqtt-bigthundersr-vehicle2/config.yaml
+++ b/onstar2mqtt-bigthundersr-vehicle2/config.yaml
@@ -2,7 +2,7 @@ name: OnStar2MQTT Home Assistant Add-on (BigThunderSR) for Vehicle 2
 version: 2.2.1
 slug: onstar2mqtt_bigthundersr_vehicle2
 description: Home Assistant Add On Version of BigThunderSR/onstar2mqtt for Vehicle 2
-codenotary: bigthundersr@outlook.com
+#codenotary: bigthundersr@outlook.com
 #startup: application
 #boot: auto
 arch:

--- a/onstar2mqtt-bigthundersr-vehicle3/config.yaml
+++ b/onstar2mqtt-bigthundersr-vehicle3/config.yaml
@@ -2,7 +2,7 @@ name: OnStar2MQTT Home Assistant Add-on (BigThunderSR) for Vehicle 3
 version: 2.2.1
 slug: onstar2mqtt_bigthundersr_vehicle3
 description: Home Assistant Add On Version of BigThunderSR/onstar2mqtt for Vehicle 3
-codenotary: bigthundersr@outlook.com
+#codenotary: bigthundersr@outlook.com
 #startup: application
 #boot: auto
 arch:

--- a/onstar2mqtt-bigthundersr-vehicle4/config.yaml
+++ b/onstar2mqtt-bigthundersr-vehicle4/config.yaml
@@ -2,7 +2,7 @@ name: OnStar2MQTT Home Assistant Add-on (BigThunderSR) for Vehicle 4
 version: 2.2.1
 slug: onstar2mqtt_bigthundersr_vehicle4
 description: Home Assistant Add On Version of BigThunderSR/onstar2mqtt for Vehicle 4
-codenotary: bigthundersr@outlook.com
+#codenotary: bigthundersr@outlook.com
 #startup: application
 #boot: auto
 arch:

--- a/x-test-onstar2mqtt-bigthundersr-vehicleX/config.yaml
+++ b/x-test-onstar2mqtt-bigthundersr-vehicleX/config.yaml
@@ -2,7 +2,7 @@ name: X - Do NOT Install - Testing - OnStar2MQTT Home Assistant Add-on (BigThund
 version: 2.2.1
 slug: x_test_onstar2mqtt_bigthundersr_vehicle1
 description: Do NOT Install - Testing - Home Assistant Add On Version of BigThunderSR/onstar2mqtt for Vehicle 1
-codenotary: bigthundersr@outlook.com
+#codenotary: bigthundersr@outlook.com
 #startup: application
 #boot: auto
 arch:

--- a/y-test-onstar2mqtt-bigthundersr-vehicleY/config.yaml
+++ b/y-test-onstar2mqtt-bigthundersr-vehicleY/config.yaml
@@ -2,7 +2,7 @@ name: Y - Do NOT Install - Testing - OnStar2MQTT Home Assistant Add-on (BigThund
 version: 2.2.1
 slug: y_test_onstar2mqtt_bigthundersr_vehicle1
 description: Do NOT Install - Testing - Home Assistant Add On Version of BigThunderSR/onstar2mqtt for Vehicle 1
-codenotary: bigthundersr@outlook.com
+#codenotary: bigthundersr@outlook.com
 #startup: application
 #boot: auto
 arch:

--- a/z-test-onstar2mqtt-bigthundersr-vehicleZ/config.yaml
+++ b/z-test-onstar2mqtt-bigthundersr-vehicleZ/config.yaml
@@ -2,7 +2,7 @@ name: Z - Do NOT Install - Testing - OnStar2MQTT Home Assistant Add-on (BigThund
 version: 2.2.1
 slug: z_test_onstar2mqtt_bigthundersr_vehicle1
 description: Do NOT Install - Testing - Home Assistant Add On Version of BigThunderSR/onstar2mqtt for Vehicle 1
-codenotary: bigthundersr@outlook.com
+#codenotary: bigthundersr@outlook.com
 #startup: application
 #boot: auto
 arch:


### PR DESCRIPTION
This pull request comments out the deprecated `codenotary` section in the `config.yaml` files for all vehicle-specific and test add-ons.
