### PR TITLE
fix: set moby=false for docker-in-docker on Debian Trixie

### DIFF
--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "homeassistant-addons-onstar2mqtt (Build)",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": { "moby": false },
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "customizations": {


### PR DESCRIPTION
The base:ubuntu image now resolves to a distribution where moby packages are unavailable. Setting moby=false installs Docker CE instead.