### PR TITLE
Migrate builder workflow to composable build-image action (2026.03.2)

### DIFF
--- a/.github/workflows/build-addon.yaml
+++ b/.github/workflows/build-addon.yaml
@@ -1,0 +1,130 @@
+name: Build addon
+
+on:
+  workflow_call:
+    inputs:
+      addon:
+        required: true
+        type: string
+      publish:
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  prepare:
+    name: Prepare ${{ inputs.addon }}
+    runs-on: ubuntu-latest
+    outputs:
+      build_matrix: ${{ steps.matrix.outputs.matrix }}
+      version: ${{ steps.matrix.outputs.version }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+
+      - name: Get addon information
+        id: info
+        uses: home-assistant/actions/helpers/info@master
+        with:
+          path: "./${{ inputs.addon }}"
+
+      - name: Prepare build matrix
+        id: matrix
+        shell: bash
+        env:
+          ARCHITECTURES: ${{ steps.info.outputs.architectures }}
+          IMAGE: ${{ steps.info.outputs.image }}
+          VERSION: ${{ steps.info.outputs.version }}
+          ADDON_PATH: "./${{ inputs.addon }}"
+        run: |
+          # Strip JSON quotes from info action outputs (yq -o=json wraps strings in quotes)
+          IMAGE="${IMAGE//\"/}"
+          VERSION="${VERSION//\"/}"
+
+          if [[ "$IMAGE" == "null" || -z "$IMAGE" ]]; then
+            echo "::error::Image property is not defined for ${{ inputs.addon }}"
+            exit 1
+          fi
+
+          # Find build file (build.yaml/yml/json) for BUILD_FROM values
+          build_file=""
+          for ext in yaml yml json; do
+            if [[ -f "${ADDON_PATH}/build.${ext}" ]]; then
+              build_file="${ADDON_PATH}/build.${ext}"
+              break
+            fi
+          done
+
+          matrix='{"include":[]}'
+          for arch in $(jq -r '.[]' <<< "${ARCHITECTURES}"); do
+            case "${arch}" in
+              amd64)   os="ubuntu-24.04" ;;
+              aarch64) os="ubuntu-24.04-arm" ;;
+              *)
+                echo "::error::Unsupported architecture: ${arch}. Supported: amd64, aarch64"
+                exit 1
+                ;;
+            esac
+            # Replace {arch} placeholder in image name from config.yaml
+            image="${IMAGE//\{arch\}/${arch}}"
+
+            # Read base image from build file
+            build_from=""
+            if [[ -n "$build_file" ]]; then
+              build_from=$(yq e -N -M ".build_from.${arch}" "$build_file")
+              if [[ "$build_from" == "null" ]]; then
+                build_from=""
+              fi
+            fi
+
+            if [[ -z "$build_from" ]]; then
+              echo "::error::No build_from defined for arch ${arch} in ${{ inputs.addon }}"
+              exit 1
+            fi
+
+            matrix=$(jq -c --arg arch "$arch" --arg os "$os" --arg image "$image" --arg build_from "$build_from" \
+              '.include += [{arch: $arch, os: $os, image: $image, build_from: $build_from}]' <<< "${matrix}")
+          done
+
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          jq . <<< "${matrix}"
+
+  build:
+    name: Build ${{ matrix.arch }} image
+    needs: prepare
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Build ${{ inputs.addon }} add-on
+        uses: home-assistant/builder/actions/build-image@2026.03.2
+        with:
+          arch: ${{ matrix.arch }}
+          build-args: |
+            BUILD_FROM=${{ matrix.build_from }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          context: "./${{ inputs.addon }}"
+          image: ${{ matrix.image }}
+          image-tags: |
+            ${{ needs.prepare.outputs.version }}
+            latest
+          push: ${{ inputs.publish }}
+          version: ${{ needs.prepare.outputs.version }}
+          #--no-cache: use cache-gha: "false" to disable caching
+        #env:
+        #  CAS_API_KEY: ${{ secrets.CAS_API_KEY }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -2,11 +2,11 @@ name: Builder
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
   packages: write
 
 env:
-  BUILD_ARGS: "--test"
   MONITORED_FILES: "build.yaml config.yaml Dockerfile rootfs"
   #MONITORED_FILES: "Dockerfile rootfs"
 
@@ -19,7 +19,7 @@ on:
     branches:
       - main
   #workflow_run:
-  #  workflows: ["Lint"]    
+  #  workflows: ["Lint"]
   #  types: [completed]
 
 concurrency:
@@ -39,6 +39,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
+        if: github.event_name != 'workflow_dispatch'
         #uses: jitterbit/get-changed-files@v1
         uses: HanseltimeIndustries/get-changed-files@v1.1.2
 
@@ -52,17 +53,27 @@ jobs:
           CHANGED_FILES: ${{ steps.changed_files.outputs.all }}
         run: |
           declare -a changed_addons
-          for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "$CHANGED_FILES" =~ $addon ]]; then
-              for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "$CHANGED_FILES" =~ $addon/$file ]]; then
-                    if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
-                      changed_addons+=("\"${addon}\",");
+
+          # Rebuild all addons on workflow_dispatch or if workflow file changed
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+             [[ "$CHANGED_FILES" =~ \.github/workflows/builder\.yaml ]] || \
+             [[ "$CHANGED_FILES" =~ \.github/workflows/build-addon\.yaml ]]; then
+            for addon in ${{ steps.addons.outputs.addons }}; do
+              changed_addons+=("\"${addon}\",")
+            done
+          else
+            for addon in ${{ steps.addons.outputs.addons }}; do
+              if [[ "$CHANGED_FILES" =~ $addon ]]; then
+                for file in ${{ env.MONITORED_FILES }}; do
+                    if [[ "$CHANGED_FILES" =~ $addon/$file ]]; then
+                      if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
+                        changed_addons+=("\"${addon}\",");
+                      fi
                     fi
-                  fi
-              done
-            fi
-          done
+                done
+              fi
+            done
+          fi
 
           changed=$(echo ${changed_addons[@]} | rev | cut -c 2- | rev)
 
@@ -73,65 +84,19 @@ jobs:
           else
             echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
           fi
+
   build:
     needs: init
-    runs-on: ubuntu-latest
     if: needs.init.outputs.changed == 'true'
-    name: Build ${{ matrix.arch }} ${{ matrix.addon }} add-on
     strategy:
+      fail-fast: false
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+    uses: ./.github/workflows/build-addon.yaml
+    with:
+      addon: ${{ matrix.addon }}
+      publish: ${{ github.event_name == 'push' }}
+    secrets: inherit
     #permissions:
     #  contents: read
     #  packages: write
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Get information
-        id: info
-        uses: home-assistant/actions/helpers/info@master
-        with:
-          path: "./${{ matrix.addon }}"
-
-      - name: Check if add-on should be built
-        id: check
-        run: |
-          if [[ "${{ steps.info.outputs.image }}" == "null" ]]; then
-            echo "Image property is not defined, skipping build"
-            echo "build_arch=false" >> $GITHUB_OUTPUT;
-          elif [[ "${{ steps.info.outputs.architectures }}" =~ ${{ matrix.arch }} ]]; then
-            echo "build_arch=true" >> $GITHUB_OUTPUT;
-            echo "image=$(echo ${{ steps.info.outputs.image }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT;
-            if [[ -z "${{ github.head_ref }}" ]] && [[ "${{ github.event_name }}" == "push" ]]; then
-                echo "BUILD_ARGS=" >> $GITHUB_ENV;
-            fi
-          else
-            echo "${{ matrix.arch }} is not a valid arch for ${{ matrix.addon }}, skipping build";
-            echo "build_arch=false" >> $GITHUB_OUTPUT;
-          fi
-
-      - name: Login to GitHub Container Registry
-        if: env.BUILD_ARGS != '--test'
-        uses: docker/login-action@v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Build ${{ matrix.addon }} add-on
-        if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2026.02.1
-        with:
-          args: |
-            ${{ env.BUILD_ARGS }} \
-            --${{ matrix.arch }} \
-            --target /data/${{ matrix.addon }} \
-            --image "${{ steps.check.outputs.image }}" \
-            --docker-hub "ghcr.io/${{ github.repository_owner }}" \
-            --addon
-            #--no-cache
-        #env:
-        #  CAS_API_KEY: ${{ secrets.CAS_API_KEY }}


### PR DESCRIPTION
## Summary

Migrates the builder workflow from the deprecated monolithic `home-assistant/builder@2026.02.1` action to the new composable `home-assistant/builder/actions/build-image@2026.03.2` action, following the official [apps-example migration](https://github.com/home-assistant/apps-example/pull/130).

## Changes

### New file: `.github/workflows/build-addon.yaml`
Reusable workflow (`workflow_call`) with two jobs:
- **prepare** (ubuntu-latest): Reads addon info via `home-assistant/actions/helpers/info@master`, constructs a build matrix with arch-specific runner OS, image name, and `BUILD_FROM` base image from `build.yaml` (with validation)
- **build** (native per-arch runner): Calls `home-assistant/builder/actions/build-image@2026.03.2` with Cosign signing and GHA build caching
- Explicit `permissions` block (`contents: read`, `id-token: write`, `packages: write`) for least-privilege and to satisfy CodeQL

### Modified: `.github/workflows/builder.yaml`
- `init` job: Added workflow_dispatch rebuild-all logic, workflow file change detection
- `build` job: Replaced inline builder invocation with `uses: ./.github/workflows/build-addon.yaml` reusable workflow call
- Added `id-token: write` to caller permissions (required for Cosign signing in reusable workflows)
- Removed deprecated arch matrix (`armhf`, `armv7`, `i386`) — only valid archs from `config.yaml` are built

## Benefits

- **Native ARM builds**: aarch64 builds run on `ubuntu-24.04-arm` instead of QEMU emulation (~3x faster)
- **No wasted jobs**: Eliminates 12 skipped arch jobs per full build (armhf/armv7/i386 × 4 addons)
- **Cosign image signing**: Automatic via `id-token: write` permission
- **GHA build caching**: Built into the composable action
- **Future-proof**: Old action will be removed eventually

## Build time comparison (estimated from v2.8.4 run #3596)

| Metric | Before | After |
|--------|--------|-------|
| aarch64 per addon | ~7 min (QEMU) | ~2-3 min (native) |
| amd64 per addon | ~2-3 min | ~2-3 min |
| Wall clock (full build) | ~7-8 min | ~3 min |
| Billable minutes | ~38 min | ~10-12 min |

## Notes

- Image naming uses `{name}-{arch}` suffix pattern (our convention) — not the new HA `{arch}-{name}` prefix. Preserves backward compatibility.
- `publish-multi-arch-manifest` is not used since our images are per-arch.
- BUILD_FROM is validated after reading from `build.yaml` — missing arch entries fail fast with a clear error.