### PR TITLE
Fix workflow_dispatch to rebuild all addons

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -53,17 +53,27 @@ jobs:
           CHANGED_FILES: ${{ steps.changed_files.outputs.all }}
         run: |
           declare -a changed_addons
-          for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "$CHANGED_FILES" =~ $addon ]]; then
-              for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "$CHANGED_FILES" =~ $addon/$file ]]; then
-                    if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
-                      changed_addons+=("\"${addon}\",");
+
+          # Rebuild all addons on workflow_dispatch or if workflow file changed
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+             [[ "$CHANGED_FILES" =~ \.github/workflows/builder\.yaml ]] || \
+             [[ "$CHANGED_FILES" =~ \.github/workflows/build-addon\.yaml ]]; then
+            for addon in ${{ steps.addons.outputs.addons }}; do
+              changed_addons+=("\"${addon}\",")
+            done
+          else
+            for addon in ${{ steps.addons.outputs.addons }}; do
+              if [[ "$CHANGED_FILES" =~ $addon ]]; then
+                for file in ${{ env.MONITORED_FILES }}; do
+                    if [[ "$CHANGED_FILES" =~ $addon/$file ]]; then
+                      if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
+                        changed_addons+=("\"${addon}\",");
+                      fi
                     fi
-                  fi
-              done
-            fi
-          done
+                done
+              fi
+            done
+          fi
 
           changed=$(echo ${changed_addons[@]} | rev | cut -c 2- | rev)
 


### PR DESCRIPTION
## Summary

Fix `workflow_dispatch` being a silent no-op — the `changed_files` step was correctly skipped on dispatch, but the `changed_addons` loop still required `$CHANGED_FILES` to match addon paths, resulting in zero addons being built.

## Changes

- Rebuild all addons on `workflow_dispatch` or when workflow files change (`.github/workflows/builder.yaml`, `.github/workflows/build-addon.yaml`)
- Normal push/PR behavior unchanged — still only builds addons with monitored file changes

## Safety

On `workflow_dispatch`, `publish` evaluates to `false`, so:
- No registry login occurs
- Images are built and discarded (not pushed to GHCR)
- No tags are overwritten
- No signing occurs